### PR TITLE
Load YAML and Base64 once in the main file

### DIFF
--- a/lib/cryppo.rb
+++ b/lib/cryppo.rb
@@ -1,3 +1,6 @@
+require 'yaml'
+require 'base64'
+
 module Cryppo
   extend self # adds instance methods as module methods.
 

--- a/lib/cryppo/encryption_values/derived_key.rb
+++ b/lib/cryppo/encryption_values/derived_key.rb
@@ -1,6 +1,3 @@
-require 'yaml'
-require 'base64'
-
 module Cryppo
   module EncryptionValues
     class DerivedKey

--- a/lib/cryppo/encryption_values/encrypted_data.rb
+++ b/lib/cryppo/encryption_values/encrypted_data.rb
@@ -1,6 +1,3 @@
-require 'yaml'
-require 'base64'
-
 module Cryppo
   module EncryptionValues
     class EncryptedData


### PR DESCRIPTION
If the library is used not with Rails and  `Cryppo.load` is called, YAML and Base64 are not loaded by that time and it leads to an error.

YAML and Base64 are required from `DerivedKey`.

I suggest that YAML and Base64 are loaded always of Cryppo is used.
