### PR TITLE
Security issue:  replace `YAML.load` with `YAML.safe_load`

### DIFF
--- a/lib/cryppo.rb
+++ b/lib/cryppo.rb
@@ -93,13 +93,13 @@ module Cryppo
 
     encryption_strategy = encryption_strategy_by_name(encryption_strategy_name).new
     encrypted_data = Base64.urlsafe_decode64(encoded_encrypted_data)
-    serialized_encryption_artefacts = YAML.load(Base64.urlsafe_decode64(encoded_encryption_artefacts))
+    serialized_encryption_artefacts = YAML.safe_load(Base64.urlsafe_decode64(encoded_encryption_artefacts))
     encryption_artefacts = encryption_strategy.deserialize_artefacts(serialized_encryption_artefacts)
     payload = EncryptionValues::EncryptedData.new(encryption_strategy, encrypted_data, **encryption_artefacts)
 
     if key_derivation_strategy_name
       key_derivation_strategy = key_derivation_strategy_by_name(key_derivation_strategy_name).new
-      serialized_derivation_artefacts = YAML.load(Base64.urlsafe_decode64(encoded_derivation_artefacts))
+      serialized_derivation_artefacts = YAML.safe_load(Base64.urlsafe_decode64(encoded_derivation_artefacts))
       derivation_artefacts = key_derivation_strategy.deserialize_artefacts(serialized_derivation_artefacts)
       derived_key_value = EncryptionValues::DerivedKey.new(key_derivation_strategy, nil, **derivation_artefacts)
       payload = EncryptionValues::EncryptedDataWithDerivedKey.new(payload, derived_key_value)


### PR DESCRIPTION
`YAML.safe_load` only allows a handful of classes in Ruby to be loaded, while `YAML.load` will load any Ruby class. Using `YAML.load` is a potential risk.

In case of Cryppo `YAML.safe_load` is more than enough.

Docs: https://ruby-doc.org/stdlib-2.6.1/libdoc/psych/rdoc/Psych.html#method-c-safe_load  (YAML in modern Ruby is a wrapper around Psych)