### PR TITLE
fix: add explicit require clause in EncryptedDataWithDerivedKey

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,11 +10,15 @@ PATCH version when you make backwards-compatible bug fixes
 
 ## Unreleased
 
+## [0.5.2] = 2020-11-30
+
+* Added `required forwardable` clause to enforce initialization of EncryptedDataWithDerivedKey::Forwardable
+
 ## [0.5.1] - 2020-06-19
 
 * Added BSON based serialization as default format
 * Added compatibility test for different Cryppo ports e.g Cryppo-js
-* Supports legacy serialization for backward compatibility 
+* Supports legacy serialization for backward compatibility
 
 ## [0.4.1] - 2010-03-18
 

--- a/lib/cryppo/encryption_values/encrypted_data_with_derived_key.rb
+++ b/lib/cryppo/encryption_values/encrypted_data_with_derived_key.rb
@@ -1,4 +1,7 @@
+require 'forwardable'
+
 module Cryppo
+
   module EncryptionValues
     class EncryptedDataWithDerivedKey
 

--- a/lib/cryppo/version.rb
+++ b/lib/cryppo/version.rb
@@ -1,3 +1,3 @@
 module Cryppo
-  VERSION = "0.5.0"
+  VERSION = "0.5.2"
 end


### PR DESCRIPTION
Forwardable is a dependency for EncryptedDataWithDerivedKey object and is not properly initialized when the required clause is missing.  

Solves problem of `uninitialized constant Cryppo::EncryptionValues::EncryptedDataWithDerivedKey::Forwardable`
