### PR TITLE
v0.6.0 release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cryppo (0.5.2)
+    cryppo (0.6.0)
       bson (> 4)
       openssl (> 2)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,9 +8,13 @@ MAJOR version when you make incompatible API changes
 MINOR version when you add functionality in a backwards-compatible manner
 PATCH version when you make backwards-compatible bug fixes
 
-## Unreleased
+## [0.6.0] - 2021-01-25
 
-## [0.5.2] = 2020-11-30
+* dropped support for legacy format (yaml)
+* added hard limit to data which can be signed with RSA signature to 512 bytes
+* added explicit check against base64 RFC 2045 encoding, rendering it as incompatible (the only supported base64 is a URL safe variant)
+
+## [0.5.2] - 2020-11-30
 
 * Added `required forwardable` clause to enforce initialization of EncryptedDataWithDerivedKey::Forwardable
 

--- a/lib/cryppo.rb
+++ b/lib/cryppo.rb
@@ -13,6 +13,7 @@ module Cryppo
   CoercionOfEncryptedKeyToString = Class.new(Error)
   UnsupportedSigningStrategy = Class.new(Error)
   InvalidSerializedValue = Class.new(Error)
+  UnsupportedBase64Encoding = Class.new(Error)
 
   autoload :Serialization, 'cryppo/serialization'
 

--- a/lib/cryppo.rb
+++ b/lib/cryppo.rb
@@ -123,14 +123,6 @@ module Cryppo
     Cryppo::Serialization.load(serialized_payload)
   end
 
-  def serialization_format_upgrade_needed?(serialized_payload)
-    !!Cryppo::Serialization.load(serialized_payload).loaded_from_legacy_version
-  end
-
-  def upgrade_serialization_format(serialized_payload)
-    Cryppo::Serialization.load(serialized_payload).serialize
-  end
-
   def sign_with_private_key(private_key_string, data)
     digest = OpenSSL::Digest.new('SHA256')
     private_key = OpenSSL::PKey::RSA.new(private_key_string)

--- a/lib/cryppo.rb
+++ b/lib/cryppo.rb
@@ -14,6 +14,7 @@ module Cryppo
   UnsupportedSigningStrategy = Class.new(Error)
   InvalidSerializedValue = Class.new(Error)
   UnsupportedBase64Encoding = Class.new(Error)
+  SignedRsaMessageTooLong = Class.new(Error)
 
   autoload :Serialization, 'cryppo/serialization'
 

--- a/lib/cryppo/encryption_values/derived_key.rb
+++ b/lib/cryppo/encryption_values/derived_key.rb
@@ -16,17 +16,10 @@ module Cryppo
         key_derivation_strategy.build_derived_key(key, self)
       end
 
-      def serialize(version: :latest_version)
+      def serialize
         serialized_artefacts = key_derivation_strategy.serialize_artefacts(derivation_artefacts)
 
-        payload = case version
-        when :legacy
-          serialized_artefacts.to_yaml
-        when :latest_version
-          serialize_artefacts_for_latest_version(serialized_artefacts)
-        else
-          raise ::Cryppo::InvalidSerializedValue, "unknown serialization format: {version}"
-        end
+        payload = serialize_artefacts_for_latest_version(serialized_artefacts)
 
         encoded_artefacts = Base64.urlsafe_encode64(payload)
         '%s.%s' % [key_derivation_strategy.strategy_name, encoded_artefacts]

--- a/lib/cryppo/encryption_values/derived_key.rb
+++ b/lib/cryppo/encryption_values/derived_key.rb
@@ -19,13 +19,13 @@ module Cryppo
       def serialize
         serialized_artefacts = key_derivation_strategy.serialize_artefacts(derivation_artefacts)
 
-        payload = serialize_artefacts_for_latest_version(serialized_artefacts)
+        payload = serialize_artefacts(serialized_artefacts)
 
         encoded_artefacts = Base64.urlsafe_encode64(payload)
         '%s.%s' % [key_derivation_strategy.strategy_name, encoded_artefacts]
       end
 
-      def serialize_artefacts_for_latest_version(serialized_artefacts)
+      def serialize_artefacts(serialized_artefacts)
         serialized_artefacts['iv'] = BSON::Binary.new(serialized_artefacts['iv'], :generic)
         Cryppo::Serialization::CURRENT_VERSION_OF_DERIVATION_ARTEFACTS + serialized_artefacts.to_bson.to_s
       end

--- a/lib/cryppo/encryption_values/encrypted_data.rb
+++ b/lib/cryppo/encryption_values/encrypted_data.rb
@@ -4,8 +4,6 @@ module Cryppo
 
       attr_reader :encryption_strategy, :encrypted_data, :encryption_artefacts
 
-      attr_accessor :loaded_from_legacy_version
-
       def initialize(encryption_strategy, encrypted_data, encryption_artefacts = {})
         @encrypted_data = encrypted_data
         @encryption_strategy = encryption_strategy
@@ -16,18 +14,11 @@ module Cryppo
         encryption_strategy.decrypt(key, self)
       end
 
-      def serialize(version: :latest_version)
+      def serialize
         encoded_encrypted_data = Base64.urlsafe_encode64(encrypted_data)
         serialized_artefacts = encryption_strategy.serialize_artefacts(encryption_artefacts)
 
-        payload = case version
-        when :legacy
-          serialized_artefacts.to_yaml
-        when :latest_version
-          serialize_artefacts_for_latest_version(serialized_artefacts)
-        else
-          raise ::Cryppo::InvalidSerializedValue, "unknown serialization format: {version}"
-        end
+        payload = serialize_artefacts_for_latest_version(serialized_artefacts)
 
         encoded_artefacts = Base64.urlsafe_encode64(payload)
         '%s.%s.%s' % [encryption_strategy.strategy_name, encoded_encrypted_data, encoded_artefacts]

--- a/lib/cryppo/encryption_values/encrypted_data.rb
+++ b/lib/cryppo/encryption_values/encrypted_data.rb
@@ -18,13 +18,13 @@ module Cryppo
         encoded_encrypted_data = Base64.urlsafe_encode64(encrypted_data)
         serialized_artefacts = encryption_strategy.serialize_artefacts(encryption_artefacts)
 
-        payload = serialize_artefacts_for_latest_version(serialized_artefacts)
+        payload = serialize_artefacts(serialized_artefacts)
 
         encoded_artefacts = Base64.urlsafe_encode64(payload)
         '%s.%s.%s' % [encryption_strategy.strategy_name, encoded_encrypted_data, encoded_artefacts]
       end
 
-      def serialize_artefacts_for_latest_version(serialized_artefacts)
+      def serialize_artefacts(serialized_artefacts)
 
         ['iv', 'at'].each do |k|
           value = serialized_artefacts[k]

--- a/lib/cryppo/encryption_values/encrypted_data_with_derived_key.rb
+++ b/lib/cryppo/encryption_values/encrypted_data_with_derived_key.rb
@@ -6,7 +6,6 @@ module Cryppo
     class EncryptedDataWithDerivedKey
 
       attr_reader :encrypted_data_value, :derived_key_value
-      attr_accessor :loaded_from_legacy_version
 
       def initialize(encrypted_data_value, derived_key_value)
         @encrypted_data_value = encrypted_data_value
@@ -22,10 +21,10 @@ module Cryppo
         derived_key_value.build_derived_key(key)
       end
 
-      def serialize(version: :latest_version)
+      def serialize
         '%s.%s' % [
-          encrypted_data_value.serialize(version: version),
-          derived_key_value.serialize(version: version)
+          encrypted_data_value.serialize,
+          derived_key_value.serialize
         ]
       end
 

--- a/lib/cryppo/encryption_values/rsa_signature.rb
+++ b/lib/cryppo/encryption_values/rsa_signature.rb
@@ -10,6 +10,7 @@ module Cryppo
         if data.bytes.length > MESSAGE_MAX_SIZE_BYTES
           raise ::Cryppo::SignedRsaMessageTooLong, "data too long to fit into serialization format, for data exceeding #{MESSAGE_MAX_SIZE_BYTES} bytes, consider signing hash of that data instead"
         end
+
         @signature = signature
         @data = data
       end

--- a/lib/cryppo/encryption_values/rsa_signature.rb
+++ b/lib/cryppo/encryption_values/rsa_signature.rb
@@ -2,7 +2,6 @@ module Cryppo
   module EncryptionValues
     class RsaSignature
       attr_reader :signature, :data
-      attr_accessor :loaded_from_legacy_version
 
       def initialize(signature, data)
         @signature = signature

--- a/lib/cryppo/encryption_values/rsa_signature.rb
+++ b/lib/cryppo/encryption_values/rsa_signature.rb
@@ -1,9 +1,15 @@
 module Cryppo
   module EncryptionValues
+
+    MESSAGE_MAX_SIZE_BYTES = 512
+
     class RsaSignature
       attr_reader :signature, :data
 
       def initialize(signature, data)
+        if data.bytes.length > MESSAGE_MAX_SIZE_BYTES
+          raise ::Cryppo::SignedRsaMessageTooLong, "data too long to fit into serialization format, for data exceeding #{MESSAGE_MAX_SIZE_BYTES} bytes, consider signing hash of that data instead"
+        end
         @signature = signature
         @data = data
       end

--- a/lib/cryppo/serialization.rb
+++ b/lib/cryppo/serialization.rb
@@ -13,23 +13,26 @@ module Cryppo::Serialization
     case chunks.size
     when 5
       b64_encoded = [chunks[1], chunks[2], chunks[4]]
-      if (is_base64_Rfc2045(*b64_encoded))
+      if is_base64_rfc2045(*b64_encoded)
         raise ::Cryppo::UnsupportedBase64Encoding, 'only URL-safe base64 is supported'
       end
+
       load_encrypted_data_with_derived_key(*chunks)
 
     when 3
       b64_encoded = chunks.last(2)
-      if (is_base64_Rfc2045(*b64_encoded))
+      if is_base64_rfc2045(*b64_encoded)
         raise ::Cryppo::UnsupportedBase64Encoding, 'only URL-safe base64 is supported'
       end
+
       load_encryption_value(*chunks)
 
     when 4
       b64_encoded = chunks.last(2)
-      if (is_base64_Rfc2045(*b64_encoded))
+      if is_base64_rfc2045(*b64_encoded)
         raise ::Cryppo::UnsupportedBase64Encoding, 'only URL-safe base64 is supported'
       end
+
       load_rsa_signature(*chunks)
 
     else
@@ -37,10 +40,8 @@ module Cryppo::Serialization
     end
   end
 
-  def is_base64_Rfc2045(*str_b64)
-    v = str_b64.any? { |str|
-      str.chars.any?{|c| c == '/' || c == '+'}
-    }
+  def is_base64_rfc2045(*str_b64)
+    str_b64.any? { |str| str.chars.any?{|c| c == '/' || c == '+'}}
   end
 
   def load_encryption_value(encryption_strategy_name, encoded_encrypted_data, encoded_encryption_artefacts_base64)

--- a/lib/cryppo/serialization.rb
+++ b/lib/cryppo/serialization.rb
@@ -12,17 +12,35 @@ module Cryppo::Serialization
 
     case chunks.size
     when 5
+      b64_encoded = [chunks[1], chunks[2], chunks[4]]
+      if (is_base64_Rfc2045(*b64_encoded))
+        raise ::Cryppo::UnsupportedBase64Encoding, 'only URL-safe base64 is supported'
+      end
       load_encrypted_data_with_derived_key(*chunks)
 
     when 3
+      b64_encoded = chunks.last(2)
+      if (is_base64_Rfc2045(*b64_encoded))
+        raise ::Cryppo::UnsupportedBase64Encoding, 'only URL-safe base64 is supported'
+      end
       load_encryption_value(*chunks)
 
     when 4
+      b64_encoded = chunks.last(2)
+      if (is_base64_Rfc2045(*b64_encoded))
+        raise ::Cryppo::UnsupportedBase64Encoding, 'only URL-safe base64 is supported'
+      end
       load_rsa_signature(*chunks)
 
     else
       raise ::Cryppo::InvalidSerializedValue, 'Invalid serialized value'
     end
+  end
+
+  def is_base64_Rfc2045(*str_b64)
+    v = str_b64.any? { |str|
+      str.chars.any?{|c| c == '/' || c == '+'}
+    }
   end
 
   def load_encryption_value(encryption_strategy_name, encoded_encrypted_data, encoded_encryption_artefacts_base64)

--- a/lib/cryppo/version.rb
+++ b/lib/cryppo/version.rb
@@ -1,3 +1,3 @@
 module Cryppo
-  VERSION = "0.5.2"
+  VERSION = "0.6.0"
 end

--- a/spec/compat_spec.rb
+++ b/spec/compat_spec.rb
@@ -16,13 +16,21 @@ RSpec.describe Cryppo do
       key = one_test['key']
       serialized = one_test['serialized']
 
-      encrypted = Cryppo.load(serialized)
-
-      if encryption_strategy == 'Aes256Gcm'
-        key = Cryppo::EncryptionValues::EncryptionKey.new(Base64.urlsafe_decode64(key))
+      begin
+        encrypted = Cryppo.load(serialized)
+      rescue ::Cryppo::InvalidSerializedValue => e
       end
-      decrypted = encrypted.decrypt(key)
-      expect(decrypted.force_encoding("UTF-8")).to eq(expected_decryption_result)
+
+      if e.nil?
+        if encryption_strategy == 'Aes256Gcm'
+          key = Cryppo::EncryptionValues::EncryptionKey.new(Base64.urlsafe_decode64(key))
+        end
+        decrypted = encrypted.decrypt(key)
+        expect(decrypted.force_encoding("UTF-8")).to eq(expected_decryption_result)
+      else
+        expect(e.message).to eq("support for yaml based format has been dropped since v0.6.0")
+      end
+
     end
   end
 
@@ -41,10 +49,16 @@ RSpec.describe Cryppo do
       passphrase = one_test['passphrase']
       serialized = one_test['serialized']
 
-      encrypted = Cryppo.load(serialized)
-      decrypted = encrypted.decrypt(passphrase)
-
-      expect(decrypted.force_encoding("UTF-8")).to eq(expected_decryption_result)
+      begin
+        encrypted = Cryppo.load(serialized)
+      rescue ::Cryppo::InvalidSerializedValue => e
+      end
+      if e.nil?
+        decrypted = encrypted.decrypt(passphrase)
+        expect(decrypted.force_encoding("UTF-8")).to eq(expected_decryption_result)
+      else
+        expect(e.message).to eq("support for yaml based format has been dropped since v0.6.0")
+      end
     end
   end
 

--- a/spec/cryppo_spec.rb
+++ b/spec/cryppo_spec.rb
@@ -169,9 +169,7 @@ RSpec.describe Cryppo do
     it 'fail to sign too large data set' do
       msg = "a" * 513
       key = OpenSSL::PKey::RSA.new(4096)
-      expect {
-        Cryppo.sign_with_private_key(key.to_s, msg)
-      }.to raise_error(::Cryppo::SignedRsaMessageTooLong)
+      expect { Cryppo.sign_with_private_key(key.to_s, msg) }.to raise_error(::Cryppo::SignedRsaMessageTooLong)
     end
 
     it 'verifying with a public key' do

--- a/spec/cryppo_spec.rb
+++ b/spec/cryppo_spec.rb
@@ -166,6 +166,14 @@ RSpec.describe Cryppo do
       expect(serialized_signature).to be_a(String)
     end
 
+    it 'fail to sign too large data set' do
+      msg = "a" * 513
+      key = OpenSSL::PKey::RSA.new(4096)
+      expect {
+        Cryppo.sign_with_private_key(key.to_s, msg)
+      }.to raise_error(::Cryppo::SignedRsaMessageTooLong)
+    end
+
     it 'verifying with a public key' do
       key = OpenSSL::PKey::RSA.new(4096)
       signature = Cryppo.sign_with_private_key(key.to_s, data)

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -1,56 +1,5 @@
 RSpec.describe 'Serialization' do
 
-  context 'upgrading serialized values' do
-    it 'encryption with a generated key' do
-
-      serialized_latest_version_format =
-        'Aes256Gcm.pH_aEk0qfLoyDK2tlZUsbr3yTCylpFNbAB6fRjoIE_kJxe1n4fYqcyLj2kYM7TkUekrcPZAoj6OC'\
-        'PkqXGVr5KVQRo15QG9fC81Ttxdoygv3VqCQpOyARWHvfzXfaNWRW-xe1Uiau.QUAAAAACYWQABQAAAG5vbmUABWF0ABAAAAAARLWTurfYXVWxyDJ_ZdJGDAVpdgAMAAAAABDbVN0dzNq0dw_i4AA='
-
-      serialized_legacy_format =
-        'Aes256Gcm.pH_aEk0qfLoyDK2tlZUsbr3yTCylpFNbAB6fRjoIE_kJxe1n4fYqcyLj2kYM7TkUekrcPZAoj6OCPkqXGVr5KVQRo15'\
-          'QG9fC81Ttxdoygv3VqCQpOyARWHvfzXfaNWRW-xe1Uiau.LS0tCidhZCc6IG5vbmUKJ2F0JzogISFiaW5hcnkgfC0KICBSTFdUdXJmWVhWV3h5REovWmRKR0RBPT0KJ2l2JzogISFiaW5hcnkgfC0KICBFTnRVM1IzTTJyUjNEK0xnCg=='
-
-      expect(Cryppo.serialization_format_upgrade_needed?(serialized_latest_version_format)).to eq(false)
-      expect(Cryppo.serialization_format_upgrade_needed?(serialized_legacy_format)).to eq(true)
-
-      upgraded = Cryppo.upgrade_serialization_format(serialized_legacy_format)
-      expect(Cryppo.serialization_format_upgrade_needed?(upgraded)).to eq(false)
-    end
-
-    it 'encryption with a derived key' do
-
-      serialized_latest_version_format =
-        'Aes256Gcm.j02apR4Y0jy6BrV_sm8pP850kJGVGLLj7i_ogyRJfv-jbyHAaBmAuU3AFTDFWyalIwl2ozfv8EN64KxOoKNqFol6HirNyJzXcB'\
-          'yQCs6qg_JttAZi21-9xvoHxKO0u3TtXwuaamcb.QUAAAAACYWQABQAAAG5vbmUABWF0ABAAAAAAFB47-aO8cExRuG7Z64fjgAVpdgAMAAAAADwhLkOj2YwXADtCIAA=.Pbkdf2Hmac.SzAAAAAQaQA-TgAABWl2ABQAAAAAfpc0yPy0psETSKUSYE8pw53TTyMQbAAgAAAAAA=='
-
-      serialized_legacy_format =
-        'Aes256Gcm.j02apR4Y0jy6BrV_sm8pP850kJGVGLLj7i_ogyRJfv-jbyHAaBmAuU3AFTDFWyalIwl2ozfv8EN64KxOoKNqFol6HirNyJzXcByQC'\
-          's6qg_JttAZi21-9xvoHxKO0u3TtXwuaamcb.LS0tCidhZCc6IG5vbmUKJ2F0JzogISFiaW5hcnkgfC0KICBGQjQ3K2FPOGNFeFJ1RzdaNjRma'\
-          'mdBPT0KJ2l2JzogISFiaW5hcnkgfC0KICBQQ0V1UTZQWmpCY0FPMElnCg==.Pbkdf2Hmac.LS0tCidpJzogMjAwMzAKJ2l2JzogISFiaW5hcnkgfC0KICBmcGMweVB5MHBzRVRTS1VTWUU4cHc1M1RUeU09CidsJzogMzIK'
-
-      expect(Cryppo.serialization_format_upgrade_needed?(serialized_latest_version_format)).to eq(false)
-      expect(Cryppo.serialization_format_upgrade_needed?(serialized_legacy_format)).to eq(true)
-
-      upgraded = Cryppo.upgrade_serialization_format(serialized_legacy_format)
-      expect(Cryppo.serialization_format_upgrade_needed?(upgraded)).to eq(false)
-    end
-
-    it 'RSA signatures' do
-      serialized =
-        'Sign.Rsa4096.zJ2l2olhXzfLnzMEfD7T2rOgVOjN1kyvJobp80qvkonBloQ_qgJJYuzrphNWMzwXdHOEKgUoVE_9uwI17iNuamu0RuIllEd6QhC'\
-          'b4kj792hG2BqurqrkvfYwk1XczZk9fK9AkHPYw4kFU2rXtdHF973Sr2IylyaLN6J42wNKAHsrk-u_4qy8t5TOkkNCvvI3AQMppqau42dZBKvieV'\
-          'vpJq29C-7y-DAvwfK1sJVIAM8M9Vv1yaT8qGOYYUnzMrChJ4PG97QQOUsnBgz1vHNHMQSNV5hxu7lLG0zi-CT00987qKefPhFzHYi3x_oEqSbjF'\
-          'aW8xtXN_OAZe5WjL3kVJSWF6bsdpyqrrGrv52ypJeJApI6P5Mxii6998IJwjQW7mYiwiNLvb5ELA6ygBFWRDS1cs-fEEUlA65_92iU8oIAILrQqW-'\
-          '5q5m-y17rrCz6NPcFT137Xxx9u6X_7dt4ZNarfmIHLeEl6Ci_755aPmAzMf7emqlvuzd-A4Glr50KCOenYhkP06pdsAgTFc5nXjq6OSumibthwX5N'\
-          'QeRwh8E2xELraFZzqxJrsvnxZavg3vFQBZOULHt6zByg4dj6SjlJlt1zOuuAb83fILltZKzKmi_kmAJggDGq1SZKPCjRPyWhQ5ywsy7CjtzChHhET'\
-          'SRxVWFmc75Wi4Y3-GJZsIbU=.RnJlc2ggTm9yd2VnaWFuIHNhbG1vbiwgbGlnaHRseSBicnVzaGVkIHdpdGggb3VyIGhlcmJlZCBEaWpvbiBtdXN0YX'\
-          'JkIHNhdWNlLCB3aXRoIGNob2ljZSBvZiB0d28gc2lkZXMu'
-
-      expect(Cryppo.serialization_format_upgrade_needed?(serialized)).to eq(false)
-    end
-  end
-
   context 'with a generated key' do
 
     let(:plain_data) { 'some plain data' }
@@ -64,21 +13,6 @@ RSpec.describe 'Serialization' do
           expect(encrypted_data).to be_a(Cryppo::EncryptionValues::EncryptedData)
 
           serialized_data = encrypted_data.serialize
-          expect(serialized_data).to be_a(String)
-
-          parts = serialized_data.split('.')
-          expect(parts.length).to eq(3)
-          expect(parts[0]).to eq(strategy_name)
-          expect(Base64.urlsafe_decode64(parts[1])).to eq(encrypted_data.encrypted_data)
-          expect(parts[2]).to_not be_nil
-        end
-
-        it 'serializes the data using the legacy format' do
-          key = Cryppo.generate_encryption_key(strategy_name)
-          encrypted_data = Cryppo.encrypt(strategy_name, key, plain_data)
-          expect(encrypted_data).to be_a(Cryppo::EncryptionValues::EncryptedData)
-
-          serialized_data = encrypted_data.serialize(version: :legacy)
           expect(serialized_data).to be_a(String)
 
           parts = serialized_data.split('.')
@@ -108,25 +42,6 @@ RSpec.describe 'Serialization' do
           expect(decrypted_data).to eq(plain_data)
         end
 
-        it 'encrypt serialize, de-serialize, decrypt using the legacy format' do
-          key = Cryppo.generate_encryption_key(strategy_name)
-          encrypted_data = Cryppo.encrypt(strategy_name, key, plain_data)
-          expect(encrypted_data).to be_a(Cryppo::EncryptionValues::EncryptedData)
-
-          serialized_data = encrypted_data.serialize(version: :legacy)
-          expect(serialized_data).to be_a(String)
-
-          loaded_encrypted_data = Cryppo.load(serialized_data)
-          expect(loaded_encrypted_data).to be_a(Cryppo::EncryptionValues::EncryptedData)
-
-          expect(loaded_encrypted_data.encryption_strategy.strategy_name).to eq(encrypted_data.encryption_strategy.strategy_name)
-          expect(loaded_encrypted_data.encryption_artefacts).to eq(encrypted_data.encryption_artefacts)
-
-          decrypted_data = loaded_encrypted_data.decrypt(key)
-          expect(decrypted_data).to be_a(String)
-
-          expect(decrypted_data).to eq(plain_data)
-        end
       end
     end
   end
@@ -161,27 +76,6 @@ RSpec.describe 'Serialization' do
           expect(parts[4]).to_not be_nil
         end
 
-        it 'serializes the data using the legacy format' do
-          encrypted_data = Cryppo.encrypt_with_derived_key(
-            strategy_name,
-            derivation_strategy_name,
-            passphrase,
-            plain_data
-          )
-          expect(encrypted_data).to be_a(Cryppo::EncryptionValues::EncryptedDataWithDerivedKey)
-
-          serialized_data = encrypted_data.serialize(version: :legacy)
-          expect(serialized_data).to be_a(String)
-
-          parts = serialized_data.split('.')
-          expect(parts.length).to eq(5)
-          expect(parts[0]).to eq(strategy_name)
-          expect(Base64.urlsafe_decode64(parts[1])).to eq(encrypted_data.encrypted_data)
-          expect(parts[2]).to_not be_nil
-          expect(parts[3]).to eq(derivation_strategy_name)
-          expect(parts[4]).to_not be_nil
-        end
-
         it 'loads the data using the latest version' do
           encrypted_data = Cryppo.encrypt_with_derived_key(
             strategy_name,
@@ -192,27 +86,6 @@ RSpec.describe 'Serialization' do
           expect(encrypted_data).to be_a(Cryppo::EncryptionValues::EncryptedDataWithDerivedKey)
 
           serialized_data = encrypted_data.serialize
-          expect(serialized_data).to be_a(String)
-
-          loaded_encrypted_data = Cryppo.load(serialized_data)
-          expect(loaded_encrypted_data).to be_a(Cryppo::EncryptionValues::EncryptedDataWithDerivedKey)
-
-          expect(loaded_encrypted_data.encryption_strategy.strategy_name).to eq(encrypted_data.encryption_strategy.strategy_name)
-          expect(loaded_encrypted_data.encryption_artefacts).to eq(encrypted_data.encryption_artefacts)
-          expect(loaded_encrypted_data.key_derivation_strategy.strategy_name).to eq(encrypted_data.key_derivation_strategy.strategy_name)
-          expect(loaded_encrypted_data.derivation_artefacts).to eq(encrypted_data.derivation_artefacts)
-        end
-
-        it 'loads the data using the legacy version' do
-          encrypted_data = Cryppo.encrypt_with_derived_key(
-            strategy_name,
-            derivation_strategy_name,
-            passphrase,
-            plain_data
-          )
-          expect(encrypted_data).to be_a(Cryppo::EncryptionValues::EncryptedDataWithDerivedKey)
-
-          serialized_data = encrypted_data.serialize(version: :legacy)
           expect(serialized_data).to be_a(String)
 
           loaded_encrypted_data = Cryppo.load(serialized_data)
@@ -245,26 +118,6 @@ RSpec.describe 'Serialization' do
           expect(decrypted_data).to eq(plain_data)
         end
 
-        it 'encrypt with a derived key, serialize, load, encrypt with the derived key using the legacy format' do
-          encrypted_data = Cryppo.encrypt_with_derived_key(
-            strategy_name,
-            derivation_strategy_name,
-            passphrase,
-            plain_data
-          )
-          expect(encrypted_data).to be_a(Cryppo::EncryptionValues::EncryptedDataWithDerivedKey)
-
-          serialized_data = encrypted_data.serialize(version: :legacy)
-          expect(serialized_data).to be_a(String)
-
-          loaded_encrypted_data = Cryppo.load(serialized_data)
-          expect(loaded_encrypted_data).to be_a(Cryppo::EncryptionValues::EncryptedDataWithDerivedKey)
-
-          decrypted_data = loaded_encrypted_data.decrypt(passphrase)
-          expect(decrypted_data).to be_a(String)
-
-          expect(decrypted_data).to eq(plain_data)
-        end
       end
     end
   end

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -44,6 +44,19 @@ RSpec.describe 'Serialization' do
 
       end
     end
+
+    it 'fail to load a message if it is encoded with basic base64 variant (not url safe)' do
+      cryppo_messages_with_plain_base64_encoding = [
+        'Aes256Gcm.MKqNIBDJd0GiSuKRtJVW.QUAAAAAFaXYADAAAAACFQp/FfChOjJ+C0lgFYXQAEAAAAABGeM6DOVX61jAE',
+        'Sign.Rsa4096.MKqNIBDJd0GiSuKRtJVW.QUAAAAAFaXYADAAAAACFQp/FfChOjJ+C0lgFYXQAEAAAAABGeM6DOVX61jAE',
+        'Aes256Gcm.MKqNIBDJd0GiSuKRtJVW.QUAAAAAFaXYADAAAAACFQp/FfChOjJ+C0lgFYXQAEAAAAABGeM6DOVX61jAE.Pbkdf2Hmac.SzAAAAAQaQA-TgAABWl2ABQAAAAAfpc0yPy0psETSKUSYE8pw53TTyMQbAAgAAAAAA=='
+      ]
+      cryppo_messages_with_plain_base64_encoding.each do |msg|
+        expect {
+          Cryppo.load(msg)
+        }.to raise_error(::Cryppo::UnsupportedBase64Encoding)
+      end
+    end
   end
 
   context 'with a derived key' do

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -52,9 +52,7 @@ RSpec.describe 'Serialization' do
         'Aes256Gcm.MKqNIBDJd0GiSuKRtJVW.QUAAAAAFaXYADAAAAACFQp/FfChOjJ+C0lgFYXQAEAAAAABGeM6DOVX61jAE.Pbkdf2Hmac.SzAAAAAQaQA-TgAABWl2ABQAAAAAfpc0yPy0psETSKUSYE8pw53TTyMQbAAgAAAAAA=='
       ]
       cryppo_messages_with_plain_base64_encoding.each do |msg|
-        expect {
-          Cryppo.load(msg)
-        }.to raise_error(::Cryppo::UnsupportedBase64Encoding)
+        expect { Cryppo.load(msg) }.to raise_error(::Cryppo::UnsupportedBase64Encoding)
       end
     end
   end


### PR DESCRIPTION
0.6.0 release:
- drop support for the old format in cryppo message (yaml)
-  limit the number of bytes to sign to 512 bytes
-  stop accepting base64 encoded cryppo messages (should always use base64 Url safe variant instead). 